### PR TITLE
Adapt to beast-base Scalable contract change

### DIFF
--- a/src/main/java/beastlabs/prevalence/PrevalenceList.java
+++ b/src/main/java/beastlabs/prevalence/PrevalenceList.java
@@ -294,20 +294,35 @@ public class PrevalenceList extends StateNode implements Scalable {
 
 	@Override
 	/** scale only those items associated with a node and leave the rest **/
-	public int scale(double fScale) {
+	public double scale(double fScale) {
 		Set<Integer> nodes = m_nodeIDtoItemMap.keySet();
 		for (Integer nNodeID : nodes) {
 			int iTime = indexOfNode(nNodeID);
-			Item item = m_items.get(iTime); 
+			Item item = m_items.get(iTime);
 			move(iTime, item.m_fTime * fScale);
 		}
-		return nodes.size();
+		return nodes.size() * Math.log(fScale);
+	}
+
+	/**
+	 * Read this list's position on its dilation axis: sum of times across all
+	 * items associated with a node. Each such time is multiplied by the scale
+	 * factor in {@link #scale(double)}, so the sum is exactly {@code s}-equivariant.
+	 */
+	@Override
+	public double getScalableValue() {
+		double sum = 0.0;
+		for (Integer nNodeID : m_nodeIDtoItemMap.keySet()) {
+			int iTime = indexOfNode(nNodeID);
+			sum += m_items.get(iTime).m_fTime;
+		}
+		return sum;
 	}
 
 	@Override
 	public void scaleOne(int i, double scale) {
 		int iTime = indexOfNode(i);
-		Item item = m_items.get(iTime); 
+		Item item = m_items.get(iTime);
 		move(iTime, item.m_fTime * scale);
 	}
 

--- a/src/main/java/beastlabs/prevalence/TreeScaleOperator.java
+++ b/src/main/java/beastlabs/prevalence/TreeScaleOperator.java
@@ -59,16 +59,18 @@ public class TreeScaleOperator extends TreeOperator {
 	        double d = Randomizer.nextDouble();
 	        double scale = (m_fScaleFactor + (d * ((1.0 / m_fScaleFactor) - m_fScaleFactor)));
 	        
-	    	Tree tree = m_tree.get(); 
+	    	Tree tree = m_tree.get();
 	        // scale the beast.tree
-	    	int nInternalNodes = tree.scale(scale);
+	        // tree.scale returns the log Jacobian (dof * log(scale));
+	        // operator adds the -2*log(scale) kernel-symmetry correction.
+	    	final double treeLogJacobian = tree.scale(scale);
 
 	    	PrevalenceList list = m_list.get();
-	    	// scale only internal nodes in the list
-	    	// nNodesScaled is the number of nodes that have been scaled
-	    	int nNodesScaled = list.scale(scale);
+	    	// scale only internal nodes in the list (return discarded —
+	    	// see TODO below; list's contribution to HR is not currently included)
+	    	list.scale(scale);
 	        // TODO: check the HastingsRatio, since the prevalence list is assumed to be unchanged here
-	        return Math.log(scale) * (nInternalNodes - 2);
+	        return treeLogJacobian - 2 * Math.log(scale);
     	} catch (Exception e) {
 			return Double.NEGATIVE_INFINITY;
 		}


### PR DESCRIPTION
## Summary

Migration to the new `beast.base.inference.Scalable` contract introduced in CompEvol/beast3#70:

- `scale(double)` return type `int → double` log Jacobian
- `getScalableValue()` added (default `setScalableValue` inherited)

Two files affected (the only places in this repo that touch `Scalable` directly):

- `PrevalenceList`: `scale` now returns `nodes.size() * Math.log(fScale)`; new `getScalableValue()` returns the sum of `m_fTime` values across items associated with a node — the s-equivariant summary under the existing scale operation.
- `TreeScaleOperator`: consume `tree.scale()` return as `double` log Jacobian; HR factored as `treeLogJacobian − 2 × log(scale)` for the kernel-symmetry term. The pre-existing `// TODO: check the HastingsRatio` about the prevalence list's contribution is preserved verbatim.

## Why

CompEvol/beast3#70 turns `Scalable` into a binding three-method contract whose invariants are mutually consistent on a single dilation axis. Any downstream package that implements `Scalable` directly needs the corresponding update; this is BEASTLabs's. Verified by parallel testing against the beast3 branch.

## Requires

beast-base 2.8.0-SNAPSHOT or newer with the contract change merged.

## Test plan

- [x] All 83 BEASTLabs tests pass against `beast3:scalable-contract` (locally installed)

## See also

CompEvol/beast3#70 — full motivation and contract description.